### PR TITLE
Updated docs to reflect the new Approov 2.6 usage for the `approov secret` command

### DIFF
--- a/docs/APPROOV_TOKEN_BINDING_QUICKSTART.md
+++ b/docs/APPROOV_TOKEN_BINDING_QUICKSTART.md
@@ -63,10 +63,10 @@ Approov tokens are signed with a symmetric secret. To verify tokens, we need to 
 Retrieve the Approov secret with:
 
 ```text
-approov secret /path/to/approov/administration.tok -get base64
+approov secret -get base64
 ```
 
-> **NOTE:** The `approov secret` command requires an administration management token to execute successfully. Developer management tokens don't have sufficient privileges to get the secret.
+> **NOTE:** The `approov secret` command requires an [administration role](https://approov.io/docs/latest/approov-usage-documentation/#account-access-roles) to execute successfully.
 
 #### Set the Approov Secret
 

--- a/docs/APPROOV_TOKEN_QUICKSTART.md
+++ b/docs/APPROOV_TOKEN_QUICKSTART.md
@@ -63,10 +63,10 @@ Approov tokens are signed with a symmetric secret. To verify tokens, we need to 
 Retrieve the Approov secret with:
 
 ```text
-approov secret /path/to/approov/administration.tok -get base64
+approov secret -get base64
 ```
 
-> **NOTE:** The `approov secret` command requires an administration management token to execute successfully. Developer management tokens don't have sufficient privileges to get the secret.
+> **NOTE:** The `approov secret` command requires an [administration role](https://approov.io/docs/latest/approov-usage-documentation/#account-access-roles) to execute successfully.
 
 #### Set the Approov Secret
 

--- a/src/approov-protected-server/token-binding-check/hello-server-protected.py
+++ b/src/approov-protected-server/token-binding-check/hello-server-protected.py
@@ -15,7 +15,7 @@ HOSTNAME = getenv('SERVER_HOSTNAME', '127.0.0.1')
 HTTP_PORT = int(getenv('HTTP_PORT', '8002'))
 
 # Token secret value obtained with the Approov CLI tool:
-#  - approov secret <admin.tok> -get
+#  - approov secret -get
 approov_base64_secret = getenv('APPROOV_BASE64_SECRET')
 
 if approov_base64_secret == None:

--- a/src/approov-protected-server/token-check/hello-server-protected.py
+++ b/src/approov-protected-server/token-check/hello-server-protected.py
@@ -14,7 +14,7 @@ HOSTNAME = getenv('SERVER_HOSTNAME', '127.0.0.1')
 HTTP_PORT = int(getenv('HTTP_PORT', '8002'))
 
 # Token secret value obtained with the Approov CLI tool:
-#  - approov secret <admin.tok> -get
+#  - approov secret -get
 approov_base64_secret = getenv('APPROOV_BASE64_SECRET')
 
 if approov_base64_secret == None:


### PR DESCRIPTION
Signed-off-by: Exadra37 <exadra37@gmail.com>